### PR TITLE
Add support for realtime logs

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -8,13 +8,13 @@
 			"Rev": "99c3df83b51532e3615f851d8c2dbb638f5313bf"
 		},
 		{
-			"ImportPath": "github.com/davecgh/go-spew/spew",
-			"Rev": "5215b55f46b2b919f50a1df0eaa5886afe4e3b3d"
+			"ImportPath": "github.com/compozed/gin",
+			"Comment": "v1.0rc1-263-g021e07a",
+			"Rev": "021e07a5e7c3af73a25d614d3a463d9bfccb9a22"
 		},
 		{
-			"ImportPath": "github.com/gin-gonic/gin",
-			"Comment": "v1.0rc1-252-g233291e",
-			"Rev": "233291e4e2d016084f9e42e786e45dad8858ace4"
+			"ImportPath": "github.com/davecgh/go-spew/spew",
+			"Rev": "5215b55f46b2b919f50a1df0eaa5886afe4e3b3d"
 		},
 		{
 			"ImportPath": "github.com/gin-gonic/gin/binding",

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,10 +1,7 @@
 {
 	"ImportPath": "github.com/compozed/deployadactyl",
-	"GoVersion": "go1.6",
+	"GoVersion": "go1.7",
 	"GodepVersion": "v74",
-	"Packages": [
-		"./..."
-	],
 	"Deps": [
 		{
 			"ImportPath": "github.com/cloudfoundry-incubator/candiedyaml",
@@ -16,22 +13,26 @@
 		},
 		{
 			"ImportPath": "github.com/gin-gonic/gin",
-			"Comment": "v1.0rc1-148-g52fcc5d",
-			"Rev": "52fcc5dbf6e94df33ad313858fb94b713e9d1b4a"
+			"Comment": "v1.0rc1-262-g5caaac4",
+			"Rev": "5caaac4c5c712a9e7a7de29e6c24ef46c753017f"
 		},
 		{
 			"ImportPath": "github.com/gin-gonic/gin/binding",
-			"Comment": "v1.0rc1-148-g52fcc5d",
-			"Rev": "52fcc5dbf6e94df33ad313858fb94b713e9d1b4a"
+			"Comment": "v1.0rc1-262-g5caaac4",
+			"Rev": "5caaac4c5c712a9e7a7de29e6c24ef46c753017f"
 		},
 		{
 			"ImportPath": "github.com/gin-gonic/gin/render",
-			"Comment": "v1.0rc1-148-g52fcc5d",
-			"Rev": "52fcc5dbf6e94df33ad313858fb94b713e9d1b4a"
+			"Comment": "v1.0rc1-262-g5caaac4",
+			"Rev": "5caaac4c5c712a9e7a7de29e6c24ef46c753017f"
 		},
 		{
 			"ImportPath": "github.com/go-errors/errors",
 			"Rev": "a41850380601eeb43f4350f7d17c6bbd8944aaf8"
+		},
+		{
+			"ImportPath": "github.com/golang/protobuf/proto",
+			"Rev": "888eb0692c857ec880338addf316bd662d5e630e"
 		},
 		{
 			"ImportPath": "github.com/kr/fs",
@@ -39,15 +40,7 @@
 		},
 		{
 			"ImportPath": "github.com/manucorporat/sse",
-			"Rev": "fe6ea2c8e398672518ef204bf0fbd9af858d0e15"
-		},
-		{
-			"ImportPath": "github.com/mattn/go-colorable",
-			"Rev": "3dac7b4f76f6e17fb39b768b89e3783d16e237fe"
-		},
-		{
-			"ImportPath": "github.com/mattn/go-isatty",
-			"Rev": "56b76bdf51f7708750eac80fa38b952bb9f32639"
+			"Rev": "ee05b128a739a0fb76c7ebd3ae4810c1de808d6d"
 		},
 		{
 			"ImportPath": "github.com/onsi/ginkgo",
@@ -219,11 +212,7 @@
 		},
 		{
 			"ImportPath": "golang.org/x/net/context",
-			"Rev": "c93a9b4f2af537028078fd467936d5bd6320e126"
-		},
-		{
-			"ImportPath": "golang.org/x/sys/unix",
-			"Rev": "442cd600860ce722f6615730eb008a37a87b13ee"
+			"Rev": "7394c112eae4dba7e96bfcfe738e6373d61772b4"
 		},
 		{
 			"ImportPath": "golang.org/x/text/transform",
@@ -234,9 +223,13 @@
 			"Rev": "cf4986612c83df6c55578ba198316d1684a9a287"
 		},
 		{
-			"ImportPath": "gopkg.in/bluesuncorp/validator.v5",
-			"Comment": "v5.12",
-			"Rev": "d5acf1dac43705f8bfbb71d878e290e2bed3950b"
+			"ImportPath": "gopkg.in/go-playground/validator.v8",
+			"Comment": "v8.18.1",
+			"Rev": "5f57d2222ad794d0dffb07e664ea05e2ee07d60c"
+		},
+		{
+			"ImportPath": "gopkg.in/yaml.v2",
+			"Rev": "e4d366fc3c7938e2958e662b4258c7a89e1f0e3e"
 		}
 	]
 }

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -13,18 +13,18 @@
 		},
 		{
 			"ImportPath": "github.com/gin-gonic/gin",
-			"Comment": "v1.0rc1-262-g5caaac4",
-			"Rev": "5caaac4c5c712a9e7a7de29e6c24ef46c753017f"
+			"Comment": "v1.0rc1-252-g233291e",
+			"Rev": "233291e4e2d016084f9e42e786e45dad8858ace4"
 		},
 		{
 			"ImportPath": "github.com/gin-gonic/gin/binding",
-			"Comment": "v1.0rc1-262-g5caaac4",
-			"Rev": "5caaac4c5c712a9e7a7de29e6c24ef46c753017f"
+			"Comment": "v1.0rc1-252-g233291e",
+			"Rev": "233291e4e2d016084f9e42e786e45dad8858ace4"
 		},
 		{
 			"ImportPath": "github.com/gin-gonic/gin/render",
-			"Comment": "v1.0rc1-262-g5caaac4",
-			"Rev": "5caaac4c5c712a9e7a7de29e6c24ef46c753017f"
+			"Comment": "v1.0rc1-252-g233291e",
+			"Rev": "233291e4e2d016084f9e42e786e45dad8858ace4"
 		},
 		{
 			"ImportPath": "github.com/go-errors/errors",
@@ -226,10 +226,6 @@
 			"ImportPath": "gopkg.in/go-playground/validator.v8",
 			"Comment": "v8.18.1",
 			"Rev": "5f57d2222ad794d0dffb07e664ea05e2ee07d60c"
-		},
-		{
-			"ImportPath": "gopkg.in/yaml.v2",
-			"Rev": "e4d366fc3c7938e2958e662b4258c7a89e1f0e3e"
 		}
 	]
 }

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "github.com/compozed/deployadactyl",
-	"GoVersion": "go1.7",
+	"GoVersion": "go1.6",
 	"GodepVersion": "v74",
 	"Deps": [
 		{

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/compozed/deployadactyl/config"
 	I "github.com/compozed/deployadactyl/interfaces"
-	"github.com/gin-gonic/gin"
+	"github.com/compozed/gin"
 	"github.com/op/go-logging"
 )
 

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -51,7 +51,7 @@ func (c *Controller) Deploy(g *gin.Context) {
 
 	contentType := g.Request.Header.Get("Content-Type")
 	if contentType == "application/json" {
-		err, statusCode = c.Deployer.Deploy(g.Request, environmentName, org, space, appName, "", contentType, buffer)
+		err, statusCode = c.Deployer.Deploy(g.Request, environmentName, org, space, appName, "", contentType, g)
 		if err != nil {
 			logError(cannotDeployApplication, statusCode, err, g, c.Log)
 			return
@@ -74,7 +74,7 @@ func (c *Controller) Deploy(g *gin.Context) {
 			}
 			defer os.RemoveAll(appPath)
 
-			err, statusCode = c.Deployer.Deploy(g.Request, environmentName, org, space, appName, appPath, contentType, buffer)
+			err, statusCode = c.Deployer.Deploy(g.Request, environmentName, org, space, appName, appPath, contentType, g)
 
 			if err != nil {
 				logError(cannotDeployApplication, statusCode, err, g, c.Log)

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -51,7 +51,7 @@ func (c *Controller) Deploy(g *gin.Context) {
 
 	contentType := g.Request.Header.Get("Content-Type")
 	if contentType == "application/json" {
-		err, statusCode = c.Deployer.Deploy(g.Request, environmentName, org, space, appName, "", contentType, g)
+		err, statusCode = c.Deployer.Deploy(g, environmentName, org, space, appName, "", contentType)
 		if err != nil {
 			logError(cannotDeployApplication, statusCode, err, g, c.Log)
 			return
@@ -74,7 +74,7 @@ func (c *Controller) Deploy(g *gin.Context) {
 			}
 			defer os.RemoveAll(appPath)
 
-			err, statusCode = c.Deployer.Deploy(g.Request, environmentName, org, space, appName, appPath, contentType, g)
+			err, statusCode = c.Deployer.Deploy(g, environmentName, org, space, appName, appPath, contentType)
 
 			if err != nil {
 				logError(cannotDeployApplication, statusCode, err, g, c.Log)

--- a/controller/controller_suite_test.go
+++ b/controller/controller_suite_test.go
@@ -1,7 +1,7 @@
 package controller_test
 
 import (
-	"github.com/gin-gonic/gin"
+	"github.com/compozed/gin"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -29,8 +29,9 @@ var _ = Describe("Controller", func() {
 		deployer     *mocks.Deployer
 		eventManager *mocks.EventManager
 		fetcher      *mocks.Fetcher
-		router       *gin.Engine
+		context      *gin.Context
 		resp         *httptest.ResponseRecorder
+		router       *gin.Engine
 
 		environment     string
 		org             string
@@ -82,8 +83,7 @@ var _ = Describe("Controller", func() {
 			appName,
 		)
 
-		router = gin.New()
-		resp = httptest.NewRecorder()
+		context, resp, router = gin.CreateTestContext()
 
 		router.POST("/v1/apps/:environment/:org/:space/:appName", controller.Deploy)
 
@@ -101,7 +101,6 @@ var _ = Describe("Controller", func() {
 				Expect(err).ToNot(HaveOccurred())
 				req.Header.Set("Content-Type", "application/json")
 
-				deployer.DeployCall.Received.Request = req
 				deployer.DeployCall.Returns.Error = nil
 				deployer.DeployCall.Returns.StatusCode = 200
 
@@ -119,8 +118,6 @@ var _ = Describe("Controller", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				req.Header.Set("Content-Type", "application/json")
-
-				deployer.DeployCall.Received.Request = req
 
 				deployer.DeployCall.Returns.Error = errors.New("internal server error")
 				deployer.DeployCall.Returns.StatusCode = 500
@@ -141,8 +138,6 @@ var _ = Describe("Controller", func() {
 				Expect(err).ToNot(HaveOccurred())
 				req.Header.Set("Content-Type", "application/zip")
 
-				deployer.DeployCall.Received.Request = req
-
 				fetcher.FetchFromZipCall.Received.RequestBody = nil
 				fetcher.FetchFromZipCall.Returns.AppPath = "appPath-" + randomizer.StringRunes(10)
 				fetcher.FetchFromZipCall.Returns.Error = nil
@@ -161,8 +156,6 @@ var _ = Describe("Controller", func() {
 				Expect(err).ToNot(HaveOccurred())
 				req.Header.Set("Content-Type", "application/zip")
 
-				deployer.DeployCall.Received.Request = req
-
 				router.ServeHTTP(resp, req)
 
 				Expect(deployer.DeployCall.TimesCalled).To(Equal(0), deployerNotEnoughCalls)
@@ -176,8 +169,6 @@ var _ = Describe("Controller", func() {
 				req, err := http.NewRequest("POST", apiURL, jsonBuffer)
 				Expect(err).ToNot(HaveOccurred())
 				req.Header.Set("Content-Type", "application/zip")
-
-				deployer.DeployCall.Received.Request = req
 
 				fetcher.FetchFromZipCall.Received.RequestBody = jsonBuffer.Bytes()
 				fetcher.FetchFromZipCall.Returns.AppPath = ""
@@ -196,8 +187,6 @@ var _ = Describe("Controller", func() {
 				req, err := http.NewRequest("POST", apiURL, jsonBuffer)
 				Expect(err).ToNot(HaveOccurred())
 				req.Header.Set("Content-Type", "application/zip")
-
-				deployer.DeployCall.Received.Request = req
 
 				fetcher.FetchFromZipCall.Received.RequestBody = jsonBuffer.Bytes()
 				fetcher.FetchFromZipCall.Returns.AppPath = "appPath-" + randomizer.StringRunes(10)

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/compozed/deployadactyl/logger"
 	"github.com/compozed/deployadactyl/mocks"
 	"github.com/compozed/deployadactyl/randomizer"
-	"github.com/gin-gonic/gin"
+	"github.com/compozed/gin"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/op/go-logging"

--- a/controller/deployer/deployer.go
+++ b/controller/deployer/deployer.go
@@ -16,7 +16,7 @@ import (
 	"github.com/compozed/deployadactyl/geterrors"
 	I "github.com/compozed/deployadactyl/interfaces"
 	S "github.com/compozed/deployadactyl/structs"
-	"github.com/gin-gonic/gin"
+	"github.com/compozed/gin"
 	"github.com/go-errors/errors"
 	"github.com/op/go-logging"
 )

--- a/controller/deployer/deployer.go
+++ b/controller/deployer/deployer.go
@@ -59,7 +59,7 @@ type Deployer struct {
 }
 
 // Deploy takes the deployment information, checks the foundations, fetches the artifact and deploys the application.
-func (d Deployer) Deploy(req *http.Request, environmentName, org, space, appName, appPath, contentType string, g *gin.Context) (err error, statusCode int) {
+func (d Deployer) Deploy(g *gin.Context, environmentName, org, space, appName, appPath, contentType string) (err error, statusCode int) {
 	var (
 		deploymentInfo         = S.DeploymentInfo{}
 		environments           = d.Config.Environments
@@ -70,14 +70,14 @@ func (d Deployer) Deploy(req *http.Request, environmentName, org, space, appName
 	)
 
 	if isJSONRequest(contentType) {
-		deploymentInfo, err = getDeploymentInfo(req.Body)
+		deploymentInfo, err = getDeploymentInfo(g.Request.Body)
 		if err != nil {
 			fmt.Fprintln(&fw, err)
 			return err, http.StatusInternalServerError
 		}
 	}
 
-	username, password, ok := req.BasicAuth()
+	username, password, ok := g.Request.BasicAuth()
 	if !ok {
 		if authenticationRequired {
 			return errors.New(basicAuthHeaderNotFound), http.StatusUnauthorized
@@ -106,7 +106,7 @@ func (d Deployer) Deploy(req *http.Request, environmentName, org, space, appName
 	deployEventData = S.DeployEventData{
 		Writer:         &fw,
 		DeploymentInfo: &deploymentInfo,
-		RequestBody:    req.Body,
+		RequestBody:    g.Request.Body,
 	}
 
 	if isJSONRequest(contentType) && deploymentInfo.Manifest != "" {

--- a/controller/deployer/deployer_test.go
+++ b/controller/deployer/deployer_test.go
@@ -62,11 +62,10 @@ var _ = Describe("Deployer", func() {
 		context         *gin.Context
 		recorder        *httptest.ResponseRecorder
 
-		deploymentInfo  S.DeploymentInfo
-		deployEventData S.DeployEventData
-		foundations     []string
-		environments    = map[string]config.Environment{}
-		log             = logger.DefaultLogger(GinkgoWriter, logging.DEBUG, "test")
+		deploymentInfo S.DeploymentInfo
+		foundations    []string
+		environments   = map[string]config.Environment{}
+		log            = logger.DefaultLogger(GinkgoWriter, logging.DEBUG, "test")
 	)
 
 	BeforeEach(func() {
@@ -109,11 +108,6 @@ var _ = Describe("Deployer", func() {
 			Space:       space,
 			AppName:     appName,
 			UUID:        uuid,
-		}
-
-		deployEventData = S.DeployEventData{
-			Writer:         &bytes.Buffer{},
-			DeploymentInfo: &deploymentInfo,
 		}
 
 		randomizerMock.RandomizeCall.Returns.Runes = uuid

--- a/controller/deployer/deployer_test.go
+++ b/controller/deployer/deployer_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/compozed/deployadactyl/mocks"
 	"github.com/compozed/deployadactyl/randomizer"
 	S "github.com/compozed/deployadactyl/structs"
-	"github.com/gin-gonic/gin"
+	"github.com/compozed/gin"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/op/go-logging"

--- a/creator/creator.go
+++ b/creator/creator.go
@@ -22,7 +22,7 @@ import (
 	I "github.com/compozed/deployadactyl/interfaces"
 	"github.com/compozed/deployadactyl/logger"
 	"github.com/compozed/deployadactyl/randomizer"
-	"github.com/gin-gonic/gin"
+	"github.com/compozed/gin"
 	"github.com/go-errors/errors"
 	"github.com/op/go-logging"
 	"github.com/spf13/afero"

--- a/flushwriter/flushwriter.go
+++ b/flushwriter/flushwriter.go
@@ -1,0 +1,33 @@
+package flushwriter
+
+import (
+	"io"
+	"net/http"
+)
+
+// FlushWriter is a writer that will flush on every write.
+type FlushWriter struct {
+	flusher http.Flusher
+	writer  io.Writer
+}
+
+// New returns a new FlushWriter.
+func New(writer io.Writer) FlushWriter {
+	fw := FlushWriter{writer: writer}
+
+	if f, ok := writer.(http.Flusher); ok {
+		fw.flusher = f
+	}
+
+	return fw
+}
+
+// Write will write p []byte to FlushWriter.writer and if it has
+// a flusher will flush the data.
+func (fw *FlushWriter) Write(p []byte) (n int, err error) {
+	n, err = fw.writer.Write(p)
+	if fw.flusher != nil {
+		fw.flusher.Flush()
+	}
+	return
+}

--- a/interfaces/bluegreener.go
+++ b/interfaces/bluegreener.go
@@ -1,13 +1,11 @@
 package interfaces
 
 import (
-	"io"
-
 	"github.com/compozed/deployadactyl/config"
 	S "github.com/compozed/deployadactyl/structs"
 )
 
 // BlueGreener interface.
 type BlueGreener interface {
-	Push(environment config.Environment, appPath string, deploymentInfo S.DeploymentInfo, out io.Writer) error
+	Push(environment config.Environment, appPath string, deploymentInfo S.DeploymentInfo, out FlushWriter) error
 }

--- a/interfaces/deployer.go
+++ b/interfaces/deployer.go
@@ -1,11 +1,12 @@
 package interfaces
 
 import (
-	"io"
 	"net/http"
+
+	"github.com/gin-gonic/gin"
 )
 
 // Deployer interface.
 type Deployer interface {
-	Deploy(req *http.Request, environment, org, space, appName, appPath, contentType string, out io.Writer) (error, int)
+	Deploy(req *http.Request, environment, org, space, appName, appPath, contentType string, g *gin.Context) (error, int)
 }

--- a/interfaces/deployer.go
+++ b/interfaces/deployer.go
@@ -1,6 +1,6 @@
 package interfaces
 
-import "github.com/gin-gonic/gin"
+import "github.com/compozed/gin"
 
 // Deployer interface.
 type Deployer interface {

--- a/interfaces/deployer.go
+++ b/interfaces/deployer.go
@@ -1,12 +1,8 @@
 package interfaces
 
-import (
-	"net/http"
-
-	"github.com/gin-gonic/gin"
-)
+import "github.com/gin-gonic/gin"
 
 // Deployer interface.
 type Deployer interface {
-	Deploy(req *http.Request, environment, org, space, appName, appPath, contentType string, g *gin.Context) (error, int)
+	Deploy(g *gin.Context, environment, org, space, appName, appPath, contentType string) (error, int)
 }

--- a/interfaces/endpoints.go
+++ b/interfaces/endpoints.go
@@ -1,6 +1,6 @@
 package interfaces
 
-import "github.com/gin-gonic/gin"
+import "github.com/compozed/gin"
 
 // Endpoints interface.
 type Endpoints interface {

--- a/interfaces/flushwriter.go
+++ b/interfaces/flushwriter.go
@@ -1,0 +1,5 @@
+package interfaces
+
+type FlushWriter interface {
+	Write(p []byte) (n int, err error)
+}

--- a/interfaces/flushwriter.go
+++ b/interfaces/flushwriter.go
@@ -1,5 +1,6 @@
 package interfaces
 
+// FlushWriter interface.
 type FlushWriter interface {
 	Write(p []byte) (n int, err error)
 }

--- a/mocks/bluegreener.go
+++ b/mocks/bluegreener.go
@@ -1,9 +1,8 @@
 package mocks
 
 import (
-	"io"
-
 	"github.com/compozed/deployadactyl/config"
+	"github.com/compozed/deployadactyl/interfaces"
 	S "github.com/compozed/deployadactyl/structs"
 )
 
@@ -14,7 +13,7 @@ type BlueGreener struct {
 			Environment    config.Environment
 			AppPath        string
 			DeploymentInfo S.DeploymentInfo
-			Out            io.Writer
+			FlushWriter    interfaces.FlushWriter
 		}
 		Returns struct {
 			Error error
@@ -23,11 +22,11 @@ type BlueGreener struct {
 }
 
 // Push mock method.
-func (b *BlueGreener) Push(environment config.Environment, appPath string, deploymentInfo S.DeploymentInfo, out io.Writer) error {
+func (b *BlueGreener) Push(environment config.Environment, appPath string, deploymentInfo S.DeploymentInfo, flushWriter interfaces.FlushWriter) error {
 	b.PushCall.Received.Environment = environment
 	b.PushCall.Received.AppPath = appPath
 	b.PushCall.Received.DeploymentInfo = deploymentInfo
-	b.PushCall.Received.Out = out
+	b.PushCall.Received.FlushWriter = flushWriter
 
 	return b.PushCall.Returns.Error
 }

--- a/mocks/deployer.go
+++ b/mocks/deployer.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/gin-gonic/gin"
+	"github.com/compozed/gin"
 )
 
 // Deployer handmade mock for tests.

--- a/mocks/deployer.go
+++ b/mocks/deployer.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+
+	"github.com/gin-gonic/gin"
 )
 
 // Deployer handmade mock for tests.
@@ -31,7 +33,7 @@ type Deployer struct {
 }
 
 // Deploy mock method.
-func (d *Deployer) Deploy(req *http.Request, environmentName, org, space, appName, appPath, contentType string, out io.Writer) (err error, statusCode int) {
+func (d *Deployer) Deploy(req *http.Request, environmentName, org, space, appName, appPath, contentType string, g *gin.Context) (err error, statusCode int) {
 	defer func() { d.DeployCall.TimesCalled++ }()
 
 	d.DeployCall.Received.Request = req
@@ -41,9 +43,11 @@ func (d *Deployer) Deploy(req *http.Request, environmentName, org, space, appNam
 	d.DeployCall.Received.AppName = appName
 	d.DeployCall.Received.AppPath = appPath
 	d.DeployCall.Received.ContentType = contentType
-	d.DeployCall.Received.Out = out
+	d.DeployCall.Received.Out = g.Writer
 
-	fmt.Fprint(out, d.DeployCall.Write.Output)
+	g.Writer.WriteHeader(d.DeployCall.Returns.StatusCode)
+
+	fmt.Fprint(g.Writer, d.DeployCall.Write.Output)
 
 	return d.DeployCall.Returns.Error, d.DeployCall.Returns.StatusCode
 }

--- a/mocks/deployer.go
+++ b/mocks/deployer.go
@@ -3,7 +3,6 @@ package mocks
 import (
 	"fmt"
 	"io"
-	"net/http"
 
 	"github.com/gin-gonic/gin"
 )
@@ -13,7 +12,7 @@ type Deployer struct {
 	DeployCall struct {
 		TimesCalled int
 		Received    struct {
-			Request         *http.Request
+			Context         *gin.Context
 			EnvironmentName string
 			Org             string
 			Space           string
@@ -33,10 +32,10 @@ type Deployer struct {
 }
 
 // Deploy mock method.
-func (d *Deployer) Deploy(req *http.Request, environmentName, org, space, appName, appPath, contentType string, g *gin.Context) (err error, statusCode int) {
+func (d *Deployer) Deploy(g *gin.Context, environmentName, org, space, appName, appPath, contentType string) (err error, statusCode int) {
 	defer func() { d.DeployCall.TimesCalled++ }()
 
-	d.DeployCall.Received.Request = req
+	d.DeployCall.Received.Context = g
 	d.DeployCall.Received.EnvironmentName = environmentName
 	d.DeployCall.Received.Org = org
 	d.DeployCall.Received.Space = space

--- a/service_tests/service_suite_test.go
+++ b/service_tests/service_suite_test.go
@@ -3,7 +3,7 @@ package service_test
 import (
 	"os"
 
-	"github.com/gin-gonic/gin"
+	"github.com/compozed/gin"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 

--- a/service_tests/service_test.go
+++ b/service_tests/service_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/compozed/deployadactyl/logger"
 	"github.com/compozed/deployadactyl/mocks"
 	"github.com/compozed/deployadactyl/randomizer"
-	"github.com/gin-gonic/gin"
+	"github.com/compozed/gin"
 	"github.com/go-errors/errors"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"


### PR DESCRIPTION
We removed the buffer that was being created in the controller and instead use the Writer that is available on the `gin.Context`. This allows us to flush the writer often and dump the output to the user.

We also created a `FlushWriter` that is a wrapper for `gin.Writer` that will automatically flush the logs every time it is written to.

In this PR we had to downgrade Gin because the `test_helpers.go` got renamed to `helpers_test.go` making it private and unusable in our tests. There is a PR to change it back to `helpers_test.go` located [here](https://github.com/gin-gonic/gin/pull/688).