### PR TITLE
add cups command to courier.go and test to courier_test.go

### DIFF
--- a/controller/deployer/bluegreen/pusher/courier/courier.go
+++ b/controller/deployer/bluegreen/pusher/courier/courier.go
@@ -64,6 +64,14 @@ func (c Courier) Exists(appName string) bool {
 	return err == nil
 }
 
+// Cups runs the Cloud Foundry CUPS command to create user provided
+// services.
+//
+// Returns the combined standard output and standard error.
+func (c Courier) Cups(appName string, body string) ([]byte, error) {
+	return c.Executor.Execute("cups", appName, "-p", body)
+}
+
 // CleanUp removes the temporary directory created by the Executor.
 func (c Courier) CleanUp() error {
 	return c.Executor.CleanUp()

--- a/controller/deployer/bluegreen/pusher/courier/courier_test.go
+++ b/controller/deployer/bluegreen/pusher/courier/courier_test.go
@@ -4,7 +4,6 @@ import (
 	. "github.com/compozed/deployadactyl/controller/deployer/bluegreen/pusher/courier"
 	"github.com/compozed/deployadactyl/mocks"
 	"github.com/compozed/deployadactyl/randomizer"
-	"github.com/compozed/deployadactyl_compozed/test"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -170,8 +169,8 @@ var _ = Describe("Courier", func() {
 	Describe("CUPS", func() {
 		It("should add a user provided service in the cloud foundry space", func() {
 			var (
-				hostName = "hostName-" + test.RandStringRunes(10)
-				address  = "address-" + test.RandStringRunes(10)
+				hostName = "hostName-" + randomizer.StringRunes(10)
+				address  = "address-" + randomizer.StringRunes(10)
 			)
 
 			body := "{" + hostName + ":" + address + "}"

--- a/controller/deployer/bluegreen/pusher/courier/courier_test.go
+++ b/controller/deployer/bluegreen/pusher/courier/courier_test.go
@@ -4,6 +4,7 @@ import (
 	. "github.com/compozed/deployadactyl/controller/deployer/bluegreen/pusher/courier"
 	"github.com/compozed/deployadactyl/mocks"
 	"github.com/compozed/deployadactyl/randomizer"
+	"github.com/compozed/deployadactyl_compozed/test"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -163,6 +164,26 @@ var _ = Describe("Courier", func() {
 			Expect(courier.Exists(appName)).To(BeTrue())
 
 			Expect(executor.ExecuteCall.Received.Args).To(Equal(expectedArgs))
+		})
+	})
+
+	Describe("CUPS", func() {
+		It("should add a user provided service in the cloud foundry space", func() {
+			var (
+				hostName = "hostName-" + test.RandStringRunes(10)
+				address  = "address-" + test.RandStringRunes(10)
+			)
+
+			body := "{" + hostName + ":" + address + "}"
+			expectedArgs := []string{"cups", appName, "-p", body}
+
+			executor.ExecuteCall.Returns.Output = []byte(output)
+			executor.ExecuteCall.Returns.Error = nil
+
+			out, err := courier.Cups(appName, body)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(executor.ExecuteCall.Received.Args).To(Equal(expectedArgs))
+			Expect(string(out)).To(Equal(output))
 		})
 	})
 

--- a/controller/deployer/bluegreen/pusher/courier/courier_test.go
+++ b/controller/deployer/bluegreen/pusher/courier/courier_test.go
@@ -1,6 +1,8 @@
 package courier_test
 
 import (
+	"fmt"
+
 	. "github.com/compozed/deployadactyl/controller/deployer/bluegreen/pusher/courier"
 	"github.com/compozed/deployadactyl/mocks"
 	"github.com/compozed/deployadactyl/randomizer"
@@ -166,21 +168,21 @@ var _ = Describe("Courier", func() {
 		})
 	})
 
-	Describe("CUPS", func() {
-		It("should add a user provided service in the cloud foundry space", func() {
+	Describe("creating user provided services", func() {
+		It("should get a valid Cloud Foundry command", func() {
 			var (
-				hostName = "hostName-" + randomizer.StringRunes(10)
-				address  = "address-" + randomizer.StringRunes(10)
+				hostName     = "hostName-" + randomizer.StringRunes(10)
+				address      = "address-" + randomizer.StringRunes(10)
+				body         = fmt.Sprintf("{%s:%s}", hostName, address)
+				expectedArgs = []string{"cups", appName, "-p", body}
 			)
-
-			body := "{" + hostName + ":" + address + "}"
-			expectedArgs := []string{"cups", appName, "-p", body}
 
 			executor.ExecuteCall.Returns.Output = []byte(output)
 			executor.ExecuteCall.Returns.Error = nil
 
 			out, err := courier.Cups(appName, body)
 			Expect(err).ToNot(HaveOccurred())
+
 			Expect(executor.ExecuteCall.Received.Args).To(Equal(expectedArgs))
 			Expect(string(out)).To(Equal(output))
 		})


### PR DESCRIPTION
Added Cups function to the courier to allow a user to create a user provided service in a cloud-foundry space.
Signed-off-by: Nathan Fitzgibbon <nfitz@allstate.com>