### PR TITLE
fix typos

### DIFF
--- a/controller/deployer/bluegreen/courier/courier.go
+++ b/controller/deployer/bluegreen/courier/courier.go
@@ -81,7 +81,7 @@ func (c Courier) Rename(appName, newAppName string) ([]byte, error) {
 	return c.Executor.Execute("rename", appName, newAppName)
 }
 
-// MapRoute runs the Cloud Foundry map-route command and added path arguement
+// MapRoute runs the Cloud Foundry map-route command and added path argument
 //
 // Returns the combined standard output and standard error.
 func (c Courier) MapRouteWithPath(appName, domain, hostname, path string) ([]byte, error) {

--- a/controller/deployer/bluegreen/courier/courier_test.go
+++ b/controller/deployer/bluegreen/courier/courier_test.go
@@ -2,8 +2,9 @@ package courier_test
 
 import (
 	"fmt"
-	. "github.com/compozed/deployadactyl/controller/deployer/bluegreen/courier"
 	"math/rand"
+
+	. "github.com/compozed/deployadactyl/controller/deployer/bluegreen/courier"
 
 	"github.com/compozed/deployadactyl/interfaces"
 	"github.com/compozed/deployadactyl/mocks"
@@ -173,7 +174,7 @@ var _ = Describe("Courier", func() {
 			Expect(executor.ExecuteCall.Received.Args).To(Equal(expectedArgs))
 			Expect(string(out)).To(Equal(output))
 		})
-		It("should get a valid Cloud Foundry map-route command with a path arguement", func() {
+		It("should get a valid Cloud Foundry map-route command with a path argument", func() {
 			var (
 				domain       = "domain-" + randomizer.StringRunes(10)
 				path         = "path-" + randomizer.StringRunes(5)

--- a/eventmanager/handlers/routemapper/routemapper_test.go
+++ b/eventmanager/handlers/routemapper/routemapper_test.go
@@ -198,7 +198,7 @@ applications:
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("calls map-route for the number of routes with a path arguement", func() {
+		It("calls map-route for the number of routes with a path argument", func() {
 			routemapper.CustomRouteMapper(routeMapperRequest)
 
 			for i := 0; i < len(routes); i++ {


### PR DESCRIPTION
fixed typos of the word argument.
My linter also just fixed ordering of imports for `courier_test.go`